### PR TITLE
[Services] Create temporary external link

### DIFF
--- a/server/features/discord/discordConfig.json
+++ b/server/features/discord/discordConfig.json
@@ -6,6 +6,12 @@
       "condition": "the message says to clear the conversation",
       "response": "our conversation has been cleared",
       "afterFunc": "clearConversation"
+    },
+    {
+      "id": "PORTAL",
+      "condition": "the message says something involving creating a portal, url, or access",
+      "response": "here is your portal",
+      "beforeFunc": "createPortal"
     }
   ]
 }

--- a/server/features/discord/discordConfig.json
+++ b/server/features/discord/discordConfig.json
@@ -13,5 +13,6 @@
       "response": "here is your portal",
       "beforeFunc": "createPortal"
     }
-  ]
+  ],
+  "PORTAL_TIMEOUT": 600000
 }

--- a/server/features/discord/messageHandlers/createPortal.js
+++ b/server/features/discord/messageHandlers/createPortal.js
@@ -1,0 +1,8 @@
+const { connect, disconnect } = require("ngrok");
+const { PORTAL_TIMEOUT } = require("../discordConfig.json");
+
+module.exports = (adv, msg, genMessage) =>
+  connect(process.env.PORT).then((url) => {
+    setTimeout(() => disconnect(url), PORTAL_TIMEOUT);
+    return `${genMessage}\n${url}`;
+  });

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "mongoose": "^7.4.1",
+    "ngrok": "^5.0.0-beta.2",
     "node-html-markdown": "^1.3.0",
     "nodemon": "^3.0.1",
     "openai": "^3.3.0",


### PR DESCRIPTION
When requested in discord (by asking for a link, portal, url, etc), generate an ngrok link that is sent to the user through slack. Have this link able to be turned off after a given time limit. This allows the web app to continue being solely on the local network while also being accessible if wanted elsewhere.