### PR TITLE
[Services] Asleep / awake detection & notification system

### DIFF
--- a/server/features/adventurer/adventurerModel.js
+++ b/server/features/adventurer/adventurerModel.js
@@ -26,6 +26,11 @@ const adventurerSchema = Schema(
       base: { type: String, default: "America/Toronto" },
       resetCurrentOn: { type: Date, default: null },
     },
+    sleepInfo: {
+      start: String,
+      end: String,
+      isAsleep: { type: Boolean, default: false },
+    },
   },
   { versionKey: false }
 );

--- a/server/features/discord/discordConfig.json
+++ b/server/features/discord/discordConfig.json
@@ -20,5 +20,11 @@
       "afterFunc": "toggleVacation"
     }
   ],
-  "PORTAL_TIMEOUT": 600000
+  "PORTAL_TIMEOUT": 600000,
+  "STATUSES": {
+    "ONLINE": "online",
+    "IDLE": "idle",
+    "OFFLINE": "offline",
+    "DND": "dnd"
+  }
 }

--- a/server/features/discord/discordModel.js
+++ b/server/features/discord/discordModel.js
@@ -17,6 +17,7 @@ const getAnyGuildUser = async (adventurer) => {
 };
 
 // Get a guild user's presence
+// (Note: returns undefined if user hasn't come online discord since app start)
 const getPresence = (adventurer) =>
   getAnyGuildUser(adventurer).then((guildMember) => guildMember?.presence);
 

--- a/server/features/shared/configs/questConfig.json
+++ b/server/features/shared/configs/questConfig.json
@@ -7,5 +7,9 @@
     "ONCE": "once",
     "WEEKEND": "weekend",
     "WEEKDAY": "weekday"
+  },
+  "SPECIAL_TIMES": {
+    "ASLEEP": "asleep",
+    "AWAKE": "awake"
   }
 }

--- a/server/jobs/cronConfig.js
+++ b/server/jobs/cronConfig.js
@@ -3,7 +3,7 @@ const discConfig = require("../features/discord/discordConfig.json");
 module.exports = {
   CLEANER_TIMEOUT: 10,
   SLEEP_STATUSES: {
-    ASLEEP: [discConfig.STATUSES.IDLE, discConfig.STATUSES.OFFLINE],
+    ASLEEP: [discConfig.STATUSES.IDLE, discConfig.STATUSES.OFFLINE, undefined],
     AWAKE: [discConfig.STATUSES.DND, discConfig.STATUSES.ONLINE],
   },
 };

--- a/server/jobs/cronConfig.js
+++ b/server/jobs/cronConfig.js
@@ -1,4 +1,5 @@
 const discConfig = require("../features/discord/discordConfig.json");
+const questConfig = require("../features/shared/configs/questConfig.json");
 
 module.exports = {
   CLEANER_TIMEOUT: 10,
@@ -6,4 +7,5 @@ module.exports = {
     ASLEEP: [discConfig.STATUSES.IDLE, discConfig.STATUSES.OFFLINE, undefined],
     AWAKE: [discConfig.STATUSES.DND, discConfig.STATUSES.ONLINE],
   },
+  SPECIAL_TIMES: questConfig.SPECIAL_TIMES,
 };

--- a/server/jobs/cronConfig.js
+++ b/server/jobs/cronConfig.js
@@ -1,0 +1,9 @@
+const discConfig = require("../features/discord/discordConfig.json");
+
+module.exports = {
+  CLEANER_TIMEOUT: 10,
+  SLEEP_STATUSES: {
+    ASLEEP: [discConfig.STATUSES.IDLE, discConfig.STATUSES.OFFLINE],
+    AWAKE: [discConfig.STATUSES.DND, discConfig.STATUSES.ONLINE],
+  },
+};

--- a/server/jobs/cronConfig.json
+++ b/server/jobs/cronConfig.json
@@ -1,3 +1,0 @@
-{
-  "CLEANER_TIMEOUT": 10
-}

--- a/server/jobs/cronFuncs/asleepChecker.js
+++ b/server/jobs/cronFuncs/asleepChecker.js
@@ -41,7 +41,7 @@ module.exports = async (checkAsleep = true) => {
   const changeInStatus = statuses.filter(([_, val]) => val);
   if (!changeInStatus.length) return;
 
-  alternateModels.ADVENTURER.updateMany(
+  await alternateModels.ADVENTURER.updateMany(
     { _id: { $in: changeInStatus.map(([id]) => id) } },
     { $set: { "sleepInfo.isAsleep": checkAsleep } }
   );

--- a/server/jobs/cronFuncs/asleepChecker.js
+++ b/server/jobs/cronFuncs/asleepChecker.js
@@ -5,11 +5,16 @@ const questReminder = require("./questReminder");
 
 module.exports = async (checkAsleep = true) => {
   // Define the below pipeline's sleep range
+  const rangeArr = [
+    { $lte: ["$sleepInfo.start", "$currTime"] },
+    { $gte: ["$sleepInfo.end", "$currTime"] },
+  ];
   let asleepCheck = {
-    $and: [
-      { $lte: ["$sleepInfo.start", "$currTime"] },
-      { $gte: ["$sleepInfo.end", "$currTime"] },
-    ],
+    $cond: {
+      if: { $lt: ["$sleepInfo.start", "$sleepInfo.end"] },
+      then: { $and: rangeArr },
+      else: { $or: rangeArr },
+    },
   };
   // Invert it if checking for awake
   if (!checkAsleep) asleepCheck = { $not: asleepCheck };

--- a/server/jobs/cronFuncs/asleepChecker.js
+++ b/server/jobs/cronFuncs/asleepChecker.js
@@ -1,7 +1,8 @@
 const { getStatus } = require("../../features/discord/discordModel");
 const alternateModels = require("../../features/shared/helpers/alternateModels");
+const { SLEEP_STATUSES } = require("../cronConfig");
 
-module.exports = async (checkAsleep = false) => {
+module.exports = async (checkAsleep = true) => {
   // Define the below pipeline's sleep range
   let asleepCheck = {
     $and: [
@@ -31,7 +32,6 @@ module.exports = async (checkAsleep = false) => {
 
   const statusProms = adventurers.map(async (adventurer) => {
     const status = await getStatus(adventurer);
-    if (!status) return;
     const validStatuses = checkAsleep
       ? SLEEP_STATUSES.ASLEEP
       : SLEEP_STATUSES.AWAKE;

--- a/server/jobs/cronFuncs/asleepChecker.js
+++ b/server/jobs/cronFuncs/asleepChecker.js
@@ -1,6 +1,6 @@
 const { getStatus } = require("../../features/discord/discordModel");
 const alternateModels = require("../../features/shared/helpers/alternateModels");
-const { SLEEP_STATUSES } = require("../cronConfig");
+const { SLEEP_STATUSES, SPECIAL_TIMES } = require("../cronConfig");
 const questReminder = require("./questReminder");
 
 module.exports = async (checkAsleep = true) => {
@@ -52,6 +52,6 @@ module.exports = async (checkAsleep = true) => {
   // Send the reminder for all quests for the changed status adventurers
   await questReminder({
     adventurer: { $in: changeInStatus.map(([id]) => id) },
-    specialTime: checkAsleep ? "sleep" : "wake",
+    specialTime: checkAsleep ? SPECIAL_TIMES.ASLEEP : SPECIAL_TIMES.AWAKE,
   });
 };

--- a/server/jobs/cronFuncs/asleepChecker.js
+++ b/server/jobs/cronFuncs/asleepChecker.js
@@ -1,0 +1,46 @@
+const { getStatus } = require("../../features/discord/discordModel");
+const alternateModels = require("../../features/shared/helpers/alternateModels");
+
+module.exports = async (checkAsleep = true) => {
+  const adventurers = await alternateModels.ADVENTURER.pipeline([
+    { $project: { discordId: 1, sleepInfo: 1 } },
+    {
+      $addFields: {
+        currTime: {
+          $dateToString: {
+            date: new Date(),
+            format: "%H:%M",
+            timezone: "$adventurer.timeZone.current",
+          },
+        },
+      },
+    },
+    {
+      $match: {
+        "sleepInfo.isAsleep": !checkAsleep,
+        // Check below logic
+        "sleepInfo.start": { [checkAsleep ? "$lt" : "$gt"]: "$currTime" },
+        "sleepInfo.end": { [checkAsleep ? "$gt" : "$lt"]: "$currTime" },
+      },
+    },
+  ]);
+  if (!adventurers.length) return;
+
+  const statusProms = adventurers.map(async (adventurer) => {
+    const status = await getStatus(adventurer);
+    if (!status) return;
+    const validStatuses = checkAsleep
+      ? SLEEP_STATUSES.ASLEEP
+      : SLEEP_STATUSES.AWAKE;
+    return [adventurer._id, validStatuses.includes(status)];
+  });
+  const statuses = await Promise.all(statusProms);
+  const changeInStatus = statuses.filter(([_, val]) => val);
+  if (!changeInStatus.length) return;
+
+  alternateModels.ADVENTURER.updateMany(
+    { _id: { $in: changeInStatus.map(([id]) => id) } },
+    { $set: { "sleepInfo.isAsleep": checkAsleep } }
+  );
+  // Run quest reminders that are for after they wake up or fall asleep
+};

--- a/server/jobs/cronFuncs/awakeChecker.js
+++ b/server/jobs/cronFuncs/awakeChecker.js
@@ -1,0 +1,3 @@
+const asleepChecker = require("./asleepChecker");
+
+module.exports = () => asleepChecker(false);

--- a/server/jobs/cronFuncs/conversationCleaner.js
+++ b/server/jobs/cronFuncs/conversationCleaner.js
@@ -1,6 +1,6 @@
 const alternateModels = require("../../features/shared/helpers/alternateModels");
 const { subMinutes } = require("date-fns");
-const { CLEANER_TIMEOUT } = require("../cronConfig.json");
+const { CLEANER_TIMEOUT } = require("../cronConfig");
 
 module.exports = () =>
   alternateModels.ADVENTURER.updateMany(

--- a/server/jobs/cronFuncs/questReminder.js
+++ b/server/jobs/cronFuncs/questReminder.js
@@ -50,9 +50,11 @@ const sendReminder = async (quests) => {
   }
 };
 
-module.exports = async () => {
+module.exports = async (query = {}) => {
+  const { specialTime, ...dbQuery } = query;
   // Get all quests that are to be reminded on
   const reminderQuests = await alternateModels.QUEST.aggregate([
+    { $match: dbQuery },
     {
       $lookup: {
         from: COLLECTION_NAMES.ADVENTURER,
@@ -100,7 +102,7 @@ module.exports = async () => {
                     as: "remind",
                     in: {
                       $and: [
-                        { $eq: ["$currTime", "$$remind.time"] },
+                        { $eq: [specialTime ?? "$currTime", "$$remind.time"] },
                         {
                           $eq: [
                             "$currDate",

--- a/server/jobs/cronHandler.js
+++ b/server/jobs/cronHandler.js
@@ -7,6 +7,8 @@ const CRONS = [
   { path: "./cronFuncs/updateRank", runtime: "0 */10 * * * *" },
   { path: "./cronFuncs/conversationCleaner", runtime: "0 * * * * *" },
   { path: "./cronFuncs/timeZoneResetter", runtime: "0 */10 * * * *" },
+  { path: "./cronFuncs/awakeChecker", runtime: "0 * * * * *" },
+  { path: "./cronFuncs/asleepChecker", runtime: "0 * * * * *" },
 ];
 
 // A system for controlling how cron jobs are logged


### PR DESCRIPTION
Detect when an adventurer is awake or asleep (more accurately on their computer or not) by using their discord status. The adventurer can specify when they are generally sleeping & awake at. Once the adventurer is asleep or awake, trigger any quest notifications that are set on asleep or awake as their time trigger. 